### PR TITLE
Support slack reminder

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -10,16 +10,32 @@ class Application
 
     private static $request;
 
-    function __construct()
+    public function __construct()
     {
-        self::$request = [
+        self::setSlackRequest();
+        self::middleware();
+    }
+
+    /**
+     * // TODO: SlackRequestクラス作ろう
+     * @return void
+     */
+    private static function setSlackRequest(): void
+    {
+        $request = [
             'token'        => $_POST['token'] ?? null,
             'channel_id'   => $_POST['channel_id'] ?? null,
+            'user_name'    => $_POST['user_name'] ?? null,
             'trigger_word' => $_POST['trigger_word'] ?? null,
             'text'         => $_POST['text'] ?? null,
+            'argument'     => trim(str_replace($_POST['trigger_word'], '', $_POST['text'])),
         ];
+        // slackリマインダー機能による投稿の場合、自動で追加される末尾ピリオドを除去します
+        if ($request['user_name'] === 'slackbot' && strpos($request['trigger_word'], 'リマインダー : ') === 0) {
+            $request['argument'] = rtrim($request['argument'], '.');
+        }
 
-        self::middleware();
+        self::$request = $request;
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -100,6 +100,7 @@ class Application
                 exit;
                 break;
             case 'ﾚﾋﾞｭｰﾏｰﾝ':
+            case 'リマインダー : ﾚﾋﾞｭｰﾏｰﾝ':
                 self::run(Components\NotificationReviewRequest::class);
                 exit;
                 break;

--- a/src/components/CreateGitHubReleaseBranch.php
+++ b/src/components/CreateGitHubReleaseBranch.php
@@ -69,7 +69,7 @@ class CreateGitHubReleaseBranch
             throw new Exception('CreateGitHubReleaseBranch::init() : .env設定して！');
         }
 
-        self::$repository = trim(str_replace($request['trigger_word'], '', $request['text']));
+        self::$repository = $request['argument'];
         if (empty(self::$repository)) {
             self::response('リポジトリ名を指定してください！');
             exit;

--- a/src/components/NotificationReviewRequest.php
+++ b/src/components/NotificationReviewRequest.php
@@ -24,7 +24,7 @@ class NotificationReviewRequest
         $githubPassword = getenv('GITHUB_PASSWORD');
 
         self::$gitRepoOwner  = getenv('GIT_REPO_OWNER');
-        self::$gitRepository = trim(str_replace($request['trigger_word'], '', $request['text']));
+        self::$gitRepository = $request['argument'];
         if (empty(self::$gitRepository)) {
             self::response('リポジトリ名を指定してください！');
             exit;


### PR DESCRIPTION
オプションを正しく受け取るため、
slackリマインダー機能経由の場合、自動で末尾に付与されるピリオドを除去しました。